### PR TITLE
fix: deploy USDi before deploying Vault

### DIFF
--- a/contracts/token/USDi.sol
+++ b/contracts/token/USDi.sol
@@ -22,7 +22,6 @@ contract USDi is Initializable, IERC20Upgradeable, ReentrancyGuardUpgradeable, A
     );
     event RebaseLocked(address _account);
     event RebaseUnlocked(address _account);
-    event SetVault(address _oldVault, address _newVault);
 
     enum RebaseOptions {
         NotSet,
@@ -64,11 +63,13 @@ contract USDi is Initializable, IERC20Upgradeable, ReentrancyGuardUpgradeable, A
         string calldata nameArg,
         string calldata symbolArg,
         uint8 decimalsArg,
+        address _vault,
         address _accessControlProxy
     ) external initializer {
         _name = nameArg;
         _symbol = symbolArg;
         _decimals = decimalsArg;
+        vault = _vault;
         _initAccessControl(_accessControlProxy);
         _rebasingCreditsPerToken = 1e18;
     }
@@ -86,12 +87,6 @@ contract USDi is Initializable, IERC20Upgradeable, ReentrancyGuardUpgradeable, A
      */
     function symbol() public view returns (string memory) {
         return _symbol;
-    }
-
-    function setVault(address _vault) external onlyRole(BocRoles.GOV_ROLE) {
-        address oldVault = _vault;
-        vault = _vault;
-        emit SetVault(oldVault, _vault);
     }
 
     /**

--- a/contracts/vault/IVault.sol
+++ b/contracts/vault/IVault.sol
@@ -193,6 +193,11 @@ interface IVault {
     function setTreasuryAddress(address _address) external;
 
     /**
+     * @dev Set the USDi address after initialization(only once)
+     */
+    function setUSDiAddress(address _address) external;
+
+    /**
      * @dev Sets the TrusteeFeeBps to the percentage of yield that should be
      *      received in basis points.
      */

--- a/contracts/vault/Vault.sol
+++ b/contracts/vault/Vault.sol
@@ -20,20 +20,16 @@ contract Vault is VaultStorage {
     using IterableIntMap for IterableIntMap.AddressToIntMap;
 
     function initialize(
-        address _usdi,
         address _accessControlProxy,
         address _treasury,
         address _exchangeManager,
         address _valueInterpreter
     ) public initializer {
-        require(_usdi != address(0), "USDi ad is 0");
         _initAccessControl(_accessControlProxy);
 
         treasury = _treasury;
         exchangeManager = _exchangeManager;
         valueInterpreter = _valueInterpreter;
-
-        usdi = USDi(_usdi);
 
         rebasePaused = false;
         // Initial redeem fee of 0 basis points

--- a/contracts/vault/VaultAdmin.sol
+++ b/contracts/vault/VaultAdmin.sol
@@ -73,6 +73,15 @@ contract VaultAdmin is VaultStorage {
         emit TreasuryAddressChanged(_address);
     }
 
+    function setUSDiAddress(address _address)
+        external
+        onlyRole(BocRoles.GOV_ROLE)
+    {
+        require(address(usdi) == address(0), "USDi has been set");
+        require(_address != address(0), "USDi ad is 0");
+        usdi = USDi(_address);
+    }
+
     /**
      * @dev Sets the TrusteeFeeBps to the percentage of yield that should be
      *      received in basis points.


### PR DESCRIPTION
* Because set vault in USDi is dangerous. Attacker can set any vault to change USDi total supply. There will not have asset loss if USDi address recorded in vault changes.